### PR TITLE
Added long press handling support

### DIFF
--- a/better-link-movement-method/src/main/java/me/saket/bettermovementmethod/BetterLinkMovementMethod.java
+++ b/better-link-movement-method/src/main/java/me/saket/bettermovementmethod/BetterLinkMovementMethod.java
@@ -223,7 +223,7 @@ public class BetterLinkMovementMethod extends LinkMovementMethod {
 
         // Toggle highlight
         if (!longPressDetected) {
-            if (touchedClickableSpan != null) {
+            if (touchedClickableSpan != null && !isFinishingEvent(event)) {
                 highlightUrl(view, touchedClickableSpan, text);
             } else {
                 removeUrlHighlightColor(view);
@@ -267,6 +267,16 @@ public class BetterLinkMovementMethod extends LinkMovementMethod {
                 return false;
         }
     }
+
+	private boolean isFinishingEvent(MotionEvent event) {
+		switch (event.getAction()) {
+			case MotionEvent.ACTION_UP:
+			case MotionEvent.ACTION_CANCEL:
+				return true;
+			default:
+				return false;
+		}
+	}
 
     private void cleanUp() {
         touchStartedOverLink = false;

--- a/better-link-movement-method/src/main/java/me/saket/bettermovementmethod/BetterLinkMovementMethod.java
+++ b/better-link-movement-method/src/main/java/me/saket/bettermovementmethod/BetterLinkMovementMethod.java
@@ -273,7 +273,7 @@ public class BetterLinkMovementMethod extends LinkMovementMethod {
 
     private void initGestureDetectorIfNeeded(Context context) {
         if (gestureDetector == null) {
-            gestureDetector = new GestureDetector(context,
+            gestureDetector = new GestureDetector(context.getApplicationContext(),
                     new GestureDetector.SimpleOnGestureListener() {
 
                         @Override

--- a/better-link-movement-method/src/main/java/me/saket/bettermovementmethod/BetterLinkMovementMethod.java
+++ b/better-link-movement-method/src/main/java/me/saket/bettermovementmethod/BetterLinkMovementMethod.java
@@ -249,7 +249,6 @@ public class BetterLinkMovementMethod extends LinkMovementMethod {
                     dispatchUrlClick(view, touchedClickableSpan);
                     removeUrlHighlightColor(view);
                 }
-                touchStartedOverLink = false;
                 cleanUp();
 
                 // Consume this event even if we could not find any spans. Android's TextView implementation
@@ -270,6 +269,7 @@ public class BetterLinkMovementMethod extends LinkMovementMethod {
     }
 
     private void cleanUp() {
+        touchStartedOverLink = false;
         longPressDetected = false;
         textViewWhereTouchStarted = null;
         touchedClickableSpan = null;

--- a/better-link-movement-method/src/main/java/me/saket/bettermovementmethod/BetterLinkMovementMethod.java
+++ b/better-link-movement-method/src/main/java/me/saket/bettermovementmethod/BetterLinkMovementMethod.java
@@ -250,8 +250,7 @@ public class BetterLinkMovementMethod extends LinkMovementMethod {
                     removeUrlHighlightColor(view);
                 }
                 touchStartedOverLink = false;
-                textViewWhereTouchStarted = null;
-                touchedClickableSpan = null;
+                cleanUp();
 
                 // Consume this event even if we could not find any spans. Android's TextView implementation
                 // has a bug where links get clicked even when there is no more text next to the link and the
@@ -259,8 +258,7 @@ public class BetterLinkMovementMethod extends LinkMovementMethod {
                 return true;
 
             case MotionEvent.ACTION_CANCEL:
-                textViewWhereTouchStarted = null;
-                touchedClickableSpan = null;
+                cleanUp();
                 return true;
 
             case MotionEvent.ACTION_MOVE:
@@ -269,6 +267,12 @@ public class BetterLinkMovementMethod extends LinkMovementMethod {
             default:
                 return false;
         }
+    }
+
+    private void cleanUp() {
+        longPressDetected = false;
+        textViewWhereTouchStarted = null;
+        touchedClickableSpan = null;
     }
 
     private void initGestureDetectorIfNeeded(Context context) {


### PR DESCRIPTION
GestureDetector is used to detect the long press. If a long press is not handled (programmer returns false in callback), then normal click can still be handled.

Addresses issue: #5 