### PR TITLE
Fix long press crash.

### DIFF
--- a/better-link-movement-method/src/main/java/me/saket/bettermovementmethod/BetterLinkMovementMethod.java
+++ b/better-link-movement-method/src/main/java/me/saket/bettermovementmethod/BetterLinkMovementMethod.java
@@ -222,7 +222,9 @@ public class BetterLinkMovementMethod extends LinkMovementMethod {
           highlightUrl(textView, clickableSpanUnderTouch, text);
         }
 
-        if (touchStartedOverALink && onLinkLongClickListener != null) {
+        if (touchStartedOverALink &&
+                onLinkLongClickListener != null &&
+                clickableSpanUnderTouch != null) {
           LongPressTimer.OnTimerReachedListener longClickListener = new LongPressTimer.OnTimerReachedListener() {
             @Override
             public void onTimerReached() {


### PR DESCRIPTION
Don't execute longClickListener if clickableSpanUnderTouch is null. This would prevent the crash when no ClickableSpan is found under the touched location.

Fixes #9 